### PR TITLE
Container updates with VS code 

### DIFF
--- a/Dockerfile-AL9-MNXB11
+++ b/Dockerfile-AL9-MNXB11
@@ -17,13 +17,12 @@ ENTRYPOINT ["/init.sh"]
 RUN dnf -y update
 # Adding epel for screen and xclock
 RUN dnf -y install epel-release
-RUN dnf -y update
 
 # Various deps
 RUN dnf -y install vim man screen xclock xorg-x11-xauth xdg-utils 
 
 # Compiler tools 
-RUN dnf -y install clang clang-tools-extra llvm clangd gdb lldb lld gold 
+RUN dnf -y install clang clang-tools-extra llvm gdb lldb lld gold 
 
 # Deps for coding e.g. building root
 RUN dnf -y install patch libuuid libuuid-devel 
@@ -34,14 +33,8 @@ RUN dnf -y install findutils gawk grep
 # Text editors 
 RUN dnf -y install code neovim emacs 
 
-# Audio dependencies 
-RUN dnf -y install portaudio-devel pipewire-jack-audio-connection-kit-devel
-
 # Deps for ROOT (see https://root.cern/install/dependencies/)
 RUN dnf -y install git make cmake gcc-c++ gcc binutils libX11-devel libXpm-devel libXft-devel libXext-devel python openssl-devel compat-openssl11
-
-# Temporary, probably not needed in the end
-RUN dnf -y install libXrandr-devel pavucontrol
 
 # Debug info 
 RUN dnf -y debuginfo-install glibc-2.34-60.el9.x86_64 libgcc-11.3.1-4.3.el9.alma.x86_64 libstdc++-11.3.1-4.3.el9.alma.x86_64

--- a/Dockerfile-AL9-MNXB11
+++ b/Dockerfile-AL9-MNXB11
@@ -1,18 +1,50 @@
 FROM almalinux:9.2
 
+
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN sh -c 'echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/vscode.repo'
+
+COPY ./scripts/init.sh /init.sh 
+RUN chmod +x /init.sh 
+
+
+CMD ["/bin/bash"]
+# Cleanup
+
+ENTRYPOINT ["/init.sh"]
+
+
 RUN dnf -y update
 # Adding epel for screen and xclock
 RUN dnf -y install epel-release
 RUN dnf -y update
 
 # Various deps
-RUN dnf -y install vim man screen xclock xorg-x11-xauth xdg-utils clang clang-tools-extra llvm
+RUN dnf -y install vim man screen xclock xorg-x11-xauth xdg-utils 
+
+# Compiler tools 
+RUN dnf -y install clang clang-tools-extra llvm clangd gdb lldb lld gold 
 
 # Deps for coding e.g. building root
-RUN dnf -y install patch libuuid libuuid-devel
+RUN dnf -y install patch libuuid libuuid-devel 
+
+# Unix utilities 
+RUN dnf -y install findutils gawk grep 
+
+# Text editors 
+RUN dnf -y install code neovim emacs 
+
+# Audio dependencies 
+RUN dnf -y install portaudio-devel pipewire-jack-audio-connection-kit-devel
 
 # Deps for ROOT (see https://root.cern/install/dependencies/)
 RUN dnf -y install git make cmake gcc-c++ gcc binutils libX11-devel libXpm-devel libXft-devel libXext-devel python openssl-devel compat-openssl11
+
+# Temporary, probably not needed in the end
+RUN dnf -y install libXrandr-devel pavucontrol
+
+# Debug info 
+RUN dnf -y debuginfo-install glibc-2.34-60.el9.x86_64 libgcc-11.3.1-4.3.el9.alma.x86_64 libstdc++-11.3.1-4.3.el9.alma.x86_64
 
 # Dir for course specific material
 ENV MNXB11_MNXB11DIR=/opt
@@ -41,4 +73,3 @@ ADD apps $MNXB11_APPS
 # Add all scripts in a scripts folder where this is ran
 ADD scripts/* ${MNXB11_SCRIPTS}/
 
-CMD ["/bin/bash"]

--- a/Dockerfile-AL9-MNXB11-dev
+++ b/Dockerfile-AL9-MNXB11-dev
@@ -1,18 +1,41 @@
 FROM almalinux:9.2
 
-RUN dnf -y update
-# Adding epel for screen and xclock
-RUN dnf -y install epel-release
-RUN dnf -y update
 
-# Various deps
-RUN dnf -y install vim man screen xclock xdg-utils
+RUN dnf -y update 
+# Addding epel for screen and xclock 
+RUN dnf -y install epel-release 
 
-# Deps for coding e.g. building root
-RUN dnf -y install patch libuuid libuuid-devel
+# Various deps 
+RUN dnf -y install vim man screen xclock xdg-utils  xorg-x11-xauth 
 
-# Deps for ROOT (see https://root.cern/install/dependencies/)
-RUN dnf -y install git make cmake gcc-c++ gcc binutils libX11-devel libXpm-devel libXft-devel libXext-devel python openssl-devel compat-openssl11
+# Deps for coding (e.g. building root
+RUN dnf -y install patch libuuid libuuid-devel 
+
+# Unix utilities 
+RUN dnf -y install findutils  
+
+# Compilation/Build tools
+RUN dnf -y install git make cmake gcc-c++ gcc binutils clang clang-tools-extra
+
+# Deps for building ROOT 
+RUN dnf -y install libX11-devel libXpm-devel libXft-devel libXext-devel python openssl-devel compat-openssl11 
+
+# Libraries 
+
+
+# It is definitely a bit of a hack 
+# RUN dnf -y update && \
+# 	dnf -y install epel-release &&         			         `# Adding epel for screen and xclock` \
+# 	dnf -y install vim man screen xclock xdg-utils &&                 `# Various deps`\
+# 	dnf -y install patch libuuid libuuid-devel findutils && `# Deps for coding e.g. building root`\
+# 	dnf -y install git make cmake gcc-c++ gcc binutils libX11-devel &&  `# Deps for ROOT `\
+# 	dnf -y install libXpm-devel libXft-devel libXext-devel &&          `# (see https://root.cern/install/dependencies/)`\
+# 	dnf -y install python openssl-devel compat-openssl11  &&           `#` \
+# 	dnf -y install code neovim emacs                      &&           `# Text editors ` \
+# 	dnf -y install xorg-x11-xauth xdg-utils         &&                 `# Utilities ` \
+# 	dnf -y install clang clang-tools-extra llvm  	&&		   `# Dev-tools ` \
+# 	dnf -y install portaudio-devel libXrandr-devel   	&&	           `# Libraries ` \
+# 	dnf -y clean all && rm -rf /var/cache/yum # Cleanup!
 
 # Dir for course specific material
 ENV MNXB11_MNXB11DIR=/opt
@@ -32,13 +55,29 @@ RUN mkdir ${MNXB11_APPS}
 ENV MNXB11_SCRIPTS=${MNXB11_MNXB11DIR}/scripts
 RUN mkdir ${MNXB11_SCRIPTS}
 
+
+
 # ROOT build
 # Download sources
-ADD https://root.cern/download/root_v6.28.04.source.tar.gz ${MNXB11_DOWNLOADS}/root_v6.28.04.source.tar.gz
+# ADD https://root.cern/download/root_v6.28.04.source.tar.gz ${MNXB11_DOWNLOADS}/root_v6.28.04.source.tar.gz
 # Unpack
-RUN tar zxf ${MNXB11_DOWNLOADS}/root_v6.28.04.source.tar.gz -C ${MNXB11_SOURCEDIR}
+# RUN tar zxf ${MNXB11_DOWNLOADS}/root_v6.28.04.source.tar.gz -C ${MNXB11_SOURCEDIR}
 
 # Add all scripts in a scripts folder where this is ran
 ADD scripts/* ${MNXB11_SCRIPTS}/
 
+
+COPY ./scripts/init.sh /init.sh 
+RUN chmod +x /init.sh 
+
+
 CMD ["/bin/bash"]
+# Cleanup
+ENTRYPOINT ["/init.sh"]
+
+
+
+
+
+
+# CMD ["/init.sh"]

--- a/Dockerfile-AL9-MNXB11-dev
+++ b/Dockerfile-AL9-MNXB11-dev
@@ -20,23 +20,6 @@ RUN dnf -y install git make cmake gcc-c++ gcc binutils clang clang-tools-extra
 # Deps for building ROOT 
 RUN dnf -y install libX11-devel libXpm-devel libXft-devel libXext-devel python openssl-devel compat-openssl11 
 
-# Libraries 
-
-
-# It is definitely a bit of a hack 
-# RUN dnf -y update && \
-# 	dnf -y install epel-release &&         			         `# Adding epel for screen and xclock` \
-# 	dnf -y install vim man screen xclock xdg-utils &&                 `# Various deps`\
-# 	dnf -y install patch libuuid libuuid-devel findutils && `# Deps for coding e.g. building root`\
-# 	dnf -y install git make cmake gcc-c++ gcc binutils libX11-devel &&  `# Deps for ROOT `\
-# 	dnf -y install libXpm-devel libXft-devel libXext-devel &&          `# (see https://root.cern/install/dependencies/)`\
-# 	dnf -y install python openssl-devel compat-openssl11  &&           `#` \
-# 	dnf -y install code neovim emacs                      &&           `# Text editors ` \
-# 	dnf -y install xorg-x11-xauth xdg-utils         &&                 `# Utilities ` \
-# 	dnf -y install clang clang-tools-extra llvm  	&&		   `# Dev-tools ` \
-# 	dnf -y install portaudio-devel libXrandr-devel   	&&	           `# Libraries ` \
-# 	dnf -y clean all && rm -rf /var/cache/yum # Cleanup!
-
 # Dir for course specific material
 ENV MNXB11_MNXB11DIR=/opt
 # Dir for all downloads
@@ -59,9 +42,9 @@ RUN mkdir ${MNXB11_SCRIPTS}
 
 # ROOT build
 # Download sources
-# ADD https://root.cern/download/root_v6.28.04.source.tar.gz ${MNXB11_DOWNLOADS}/root_v6.28.04.source.tar.gz
+ADD https://root.cern/download/root_v6.28.04.source.tar.gz ${MNXB11_DOWNLOADS}/root_v6.28.04.source.tar.gz
 # Unpack
-# RUN tar zxf ${MNXB11_DOWNLOADS}/root_v6.28.04.source.tar.gz -C ${MNXB11_SOURCEDIR}
+RUN tar zxf ${MNXB11_DOWNLOADS}/root_v6.28.04.source.tar.gz -C ${MNXB11_SOURCEDIR}
 
 # Add all scripts in a scripts folder where this is ran
 ADD scripts/* ${MNXB11_SCRIPTS}/

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,61 @@
+!/#bin/bash
+
+#!/bin/bash
+
+# Check if the folder MNXB11_APPS exists
+if [ -d "MNXB11_APPS" ]; then
+  # Loop through each subdirectory in MNXB11_APPS
+  for directory in MNXB11_APPS/*; do
+    # If the 'bin' folder exists, add it to the PATH variable
+    if [ -d "$directory/bin" ]; then
+      # 'bin' folders contain executable programs, adding them to PATH allows
+      # running them from any directory
+      export PATH="$directory/bin:$PATH"
+    fi
+
+    # If the 'lib' folder exists, add it to the LD_LIBRARY_PATH variable
+    if [ -d "$directory/lib" ]; then
+      # 'lib' folders contain shared libraries, adding them to LD_LIBRARY_PATH
+      # helps programs find required libraries during runtime
+      export LD_LIBRARY_PATH="$directory/lib:$LD_LIBRARY_PATH"
+    fi
+
+    # If the 'lib64' folder exists, add it to the LD_LIBRARY_PATH variable
+    if [ -d "$directory/lib64" ]; then
+      # Some systems use 'lib64' to store 64-bit libraries, also added to
+      # LD_LIBRARY_PATH for compatibility
+      export LD_LIBRARY_PATH="$directory/lib64:$LD_LIBRARY_PATH"
+    fi
+
+    # If the 'cmake' folder exists, add it to the CMAKE_PREFIX_PATH variable
+    if [ -d "$directory/cmake" ]; then
+      # 'cmake' folders contain CMake configuration files for libraries and
+      # projects, adding them to CMAKE_PREFIX_PATH helps CMake find dependencies
+      # during the build process
+      export CMAKE_PREFIX_PATH="$directory/cmake:$CMAKE_PREFIX_PATH"
+    fi
+    # If the 'pkgconfig' folder exists, add it to the PKG_CONFIG_PATH variable
+    if [ -d "$directory/pkgconfig" ]; then
+      # 'pkgconfig' folders contain metadata files used by pkg-config utility to
+      # find library and compiler flags, adding them to PKG_CONFIG_PATH helps in
+      # compilation and linking
+      export PKG_CONFIG_PATH="$directory/pkgconfig:$PKG_CONFIG_PATH"
+    fi
+
+    if [ -d "$directory/include" ]; then
+      # 'include' folders usually contain header files required for development,
+      # adding them to C_INCLUDE_PATH or CPLUS_INCLUDE_PATH can help compilers
+      # find headers
+      export C_INCLUDE_PATH="$directory/include:$C_INCLUDE_PATH"
+      export CPLUS_INCLUDE_PATH="$directory/include:$CPLUS_INCLUDE_PATH"
+    fi
+
+    if [ -d "$directory/share" ]; then
+      # 'share' folders may contain data files or other resources, adding them
+      # to XDG_DATA_DIRS can help applications find these resources
+      export XDG_DATA_DIRS="$directory/share:$XDG_DATA_DIRS"
+    fi
+
+    # Add any other important development directories as needed here ...
+  done
+fi

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,11 +1,9 @@
-!/#bin/bash
-
 #!/bin/bash
 
 # Check if the folder MNXB11_APPS exists
-if [ -d "MNXB11_APPS" ]; then
+if [ -d "$MNXB11_APPS" ]; then
   # Loop through each subdirectory in MNXB11_APPS
-  for directory in MNXB11_APPS/*; do
+  for directory in $MNXB11_APPS/*; do
     # If the 'bin' folder exists, add it to the PATH variable
     if [ -d "$directory/bin" ]; then
       # 'bin' folders contain executable programs, adding them to PATH allows
@@ -59,3 +57,7 @@ if [ -d "MNXB11_APPS" ]; then
     # Add any other important development directories as needed here ...
   done
 fi
+
+
+# Run the default command or override it with any command passed as arguments
+exec "$@"


### PR DESCRIPTION
Hi, 

here's what I did before the holiday season. It's been a while since I worked with it but this was enough to have a container that is able to run both ROOT and Vs code on cosmos. 

In order for graphical things to work, the singularity container needs to bind mount both $XAUTHORITY and the /run/user directory e.g. like 
```
apptainer run -B $XAUTHORITY:$XAUTHORITY -B /run/user:/run/user mnxb11-container_latest.sif  
``` 
The /run/user is necessary for VS code  

In addition to VS code, I've added the following packages 
- Some compiler/debugger tools `clang clang-tools-extra llvm gdb lldb lld gold`
- Some basic unix tools that I ended up having use fore `gawk, grep, findutils` 
- Emacs and neovim, I expect that we will have at least some student that is into using these so having them available seems like it is a good idea. We don't provide any support for it in the course though 
- Some debug info for the standard/C library 

I've also added an init script that adds any necessary PATH, LD_LIBRARY_PATH, etc from things installed in the MNXB11_APPS folder automatically 

